### PR TITLE
fix: prevent recursive pagination and add list_courses filter params

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,6 @@
 // src/client.ts
 
-import axios, { AxiosInstance, AxiosError } from 'axios';
+import axios, { AxiosInstance, AxiosError, AxiosRequestConfig } from 'axios';
 import { 
   CanvasCourse, 
   CanvasAssignment,
@@ -85,14 +85,25 @@ export class CanvasClient {
         const contentType = headers['content-type'] || '';
 
         // Only handle pagination for JSON responses
+        // Use axios directly (not this.client) to avoid recursive interceptor calls
         if (Array.isArray(data) && linkHeader && contentType.includes('application/json')) {
           let allData = [...data];
           let nextUrl = this.getNextPageUrl(linkHeader);
+          const paginationConfig: AxiosRequestConfig = {
+            headers: {
+              'Authorization': response.config.headers['Authorization'] as string,
+              'Content-Type': 'application/json'
+            },
+            timeout: 30000
+          };
 
           while (nextUrl) {
-            const nextResponse = await this.client.get(nextUrl);
+            console.error(`[Canvas API] GET ${nextUrl}`);
+            const nextResponse = await axios.get(nextUrl, paginationConfig);
             allData = [...allData, ...nextResponse.data];
-            nextUrl = this.getNextPageUrl(nextResponse.headers.link);
+            nextUrl = nextResponse.headers.link
+              ? this.getNextPageUrl(nextResponse.headers.link)
+              : null;
           }
 
           response.data = allData;
@@ -209,17 +220,38 @@ export class CanvasClient {
   // ---------------------
   // COURSES (Enhanced)
   // ---------------------
-  async listCourses(includeEnded: boolean = false): Promise<CanvasCourse[]> {
+  async listCourses(options: {
+    includeEnded?: boolean;
+    limit?: number;
+    enrollmentState?: string;
+  } | boolean = {}): Promise<CanvasCourse[]> {
+    // Support legacy boolean signature
+    const opts = typeof options === 'boolean' ? { includeEnded: options } : options;
+    const { includeEnded = false, limit, enrollmentState } = opts;
     const params: any = {
       include: ['total_students', 'teachers', 'term', 'course_progress']
     };
-    
+
     if (!includeEnded) {
       params.state = ['available', 'completed'];
     }
 
+    if (enrollmentState) {
+      params.enrollment_state = enrollmentState;
+    }
+
+    if (limit) {
+      params.per_page = Math.min(limit, 100);
+    }
+
     const response = await this.client.get('/courses', { params });
-    return response.data;
+    let courses: CanvasCourse[] = response.data;
+
+    if (limit) {
+      courses = courses.slice(0, limit);
+    }
+
+    return courses;
   }
 
   async getCourse(courseId: number): Promise<CanvasCourse> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,10 @@ const RAW_TOOLS: Tool[] = [
     inputSchema: {
       type: "object",
       properties: {
-        include_ended: { type: "boolean", description: "Include ended courses" }
+        include_ended: { type: "boolean", description: "Include ended courses" },
+        limit: { type: "number", description: "Max number of courses to return (default: all)" },
+        enrollment_state: { type: "string", enum: ["active", "invited_or_pending", "completed"], description: "Filter by enrollment state" },
+        slim: { type: "boolean", description: "Return only id, name, course_code, term name, and workflow_state" }
       },
       required: []
     }
@@ -1302,8 +1305,17 @@ export class CanvasMCPServer {
 
           // Course management
           case "canvas_list_courses": {
-            const { include_ended = false } = args as { include_ended?: boolean };
-            const courses = await this.client.listCourses(include_ended);
+            const { include_ended = false, limit, enrollment_state, slim = false } = args as {
+              include_ended?: boolean; limit?: number; enrollment_state?: string; slim?: boolean;
+            };
+            const courses = await this.client.listCourses({ includeEnded: include_ended, limit, enrollmentState: enrollment_state });
+            if (slim) {
+              const slimCourses = courses.map(c => ({
+                id: c.id, name: c.name, course_code: c.course_code,
+                term: (c as any).term?.name, workflow_state: c.workflow_state
+              }));
+              return { content: [{ type: "text", text: JSON.stringify(slimCourses, null, 2) }] };
+            }
             return {
               content: [{ type: "text", text: this.serializeToolOutput(courses, includeRaw) }]
             };


### PR DESCRIPTION
## Summary

- **Fix recursive pagination**: The response interceptor was calling `this.client.get()` for subsequent pages, which re-triggered the interceptor itself causing infinite recursion. Fixed by using bare `axios.get()` with an explicit `paginationConfig` that carries the Authorization header, bypassing the interceptor for pagination requests.
- **Fix 401 on paginated requests**: By passing the Authorization header explicitly in `paginationConfig`, subsequent page fetches no longer drop credentials.
- **Add `list_courses` filter params**: Adds `limit`, `enrollment_state`, and `slim` params to the `canvas_list_courses` tool and the underlying `listCourses()` client method.

## Details

### Pagination fix (`src/client.ts`)
```
// Before (recursive — interceptor fires again on each page fetch)
const nextResponse = await this.client.get(nextUrl);

// After (bypasses interceptor, carries auth header)
const nextResponse = await axios.get(nextUrl, paginationConfig);
```

### New `list_courses` params
| Param | Type | Description |
|-------|------|-------------|
| `limit` | number | Max courses to return |
| `enrollment_state` | `active` \| `invited_or_pending` \| `completed` | Filter by enrollment state |
| `slim` | boolean | Return only id, name, course_code, term, workflow_state |

## Test plan
- [x] `canvas_list_courses` with `limit=5` returns exactly 5 courses
- [x] `canvas_list_courses` with `enrollment_state=active` correctly filters results
- [x] `canvas_list_courses` with `slim=true` returns compact output
- [x] `canvas_list_assignments` on a course with 38 assignments (spanning multiple pages) returns all 38 — confirms pagination interceptor no longer recurses

🤖 Generated with [Claude Code](https://claude.com/claude-code)