### PR TITLE
Fix course pagination limits from PR #14

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,6 @@
 // src/client.ts
 
-import axios, { AxiosInstance, AxiosError } from 'axios';
+import axios, { AxiosInstance, AxiosError, AxiosRequestConfig } from 'axios';
 import { 
   CanvasCourse, 
   CanvasAssignment,
@@ -85,14 +85,25 @@ export class CanvasClient {
         const contentType = headers['content-type'] || '';
 
         // Only handle pagination for JSON responses
+        // Use axios directly (not this.client) to avoid recursive interceptor calls
         if (Array.isArray(data) && linkHeader && contentType.includes('application/json')) {
           let allData = [...data];
           let nextUrl = this.getNextPageUrl(linkHeader);
+          const paginationConfig: AxiosRequestConfig = {
+            headers: {
+              'Authorization': response.config.headers['Authorization'] as string,
+              'Content-Type': 'application/json'
+            },
+            timeout: 30000
+          };
 
           while (nextUrl) {
-            const nextResponse = await this.client.get(nextUrl);
+            console.error(`[Canvas API] GET ${nextUrl}`);
+            const nextResponse = await axios.get(nextUrl, paginationConfig);
             allData = [...allData, ...nextResponse.data];
-            nextUrl = this.getNextPageUrl(nextResponse.headers.link);
+            nextUrl = nextResponse.headers.link
+              ? this.getNextPageUrl(nextResponse.headers.link)
+              : null;
           }
 
           response.data = allData;
@@ -209,17 +220,38 @@ export class CanvasClient {
   // ---------------------
   // COURSES (Enhanced)
   // ---------------------
-  async listCourses(includeEnded: boolean = false): Promise<CanvasCourse[]> {
+  async listCourses(options: {
+    includeEnded?: boolean;
+    limit?: number;
+    enrollmentState?: string;
+  } | boolean = {}): Promise<CanvasCourse[]> {
+    // Support legacy boolean signature
+    const opts = typeof options === 'boolean' ? { includeEnded: options } : options;
+    const { includeEnded = false, limit, enrollmentState } = opts;
     const params: any = {
       include: ['total_students', 'teachers', 'term', 'course_progress']
     };
-    
+
     if (!includeEnded) {
       params.state = ['available', 'completed'];
     }
 
+    if (enrollmentState) {
+      params.enrollment_state = enrollmentState;
+    }
+
+    if (limit) {
+      params.per_page = Math.min(limit, 100);
+    }
+
     const response = await this.client.get('/courses', { params });
-    return response.data;
+    let courses: CanvasCourse[] = response.data;
+
+    if (limit) {
+      courses = courses.slice(0, limit);
+    }
+
+    return courses;
   }
 
   async getCourse(courseId: number): Promise<CanvasCourse> {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,8 +1,8 @@
 // src/client.ts
 
 import axios, { AxiosInstance, AxiosError, AxiosRequestConfig } from 'axios';
-import { 
-  CanvasCourse, 
+import {
+  CanvasCourse,
   CanvasAssignment,
   CanvasSubmission,
   CanvasUser,
@@ -40,6 +40,10 @@ import {
   ListAccountCoursesArgs,
   ListAccountUsersArgs
 } from './types.js';
+
+type PaginatedRequestConfig = AxiosRequestConfig & {
+  paginationLimit?: number;
+};
 
 export class CanvasClient {
   private client: AxiosInstance;
@@ -89,15 +93,13 @@ export class CanvasClient {
         if (Array.isArray(data) && linkHeader && contentType.includes('application/json')) {
           let allData = [...data];
           let nextUrl = this.getNextPageUrl(linkHeader);
+          const paginationLimit = (response.config as PaginatedRequestConfig).paginationLimit;
           const paginationConfig: AxiosRequestConfig = {
-            headers: {
-              'Authorization': response.config.headers['Authorization'] as string,
-              'Content-Type': 'application/json'
-            },
-            timeout: 30000
+            headers: response.config.headers,
+            timeout: response.config.timeout ?? 30000
           };
 
-          while (nextUrl) {
+          while (nextUrl && (!paginationLimit || allData.length < paginationLimit)) {
             console.error(`[Canvas API] GET ${nextUrl}`);
             const nextResponse = await axios.get(nextUrl, paginationConfig);
             allData = [...allData, ...nextResponse.data];
@@ -106,7 +108,7 @@ export class CanvasClient {
               : null;
           }
 
-          response.data = allData;
+          response.data = paginationLimit ? allData.slice(0, paginationLimit) : allData;
         }
 
         return response;
@@ -228,6 +230,14 @@ export class CanvasClient {
     // Support legacy boolean signature
     const opts = typeof options === 'boolean' ? { includeEnded: options } : options;
     const { includeEnded = false, limit, enrollmentState } = opts;
+    const paginationLimit = typeof limit === 'number' && Number.isFinite(limit)
+      ? Math.max(0, Math.floor(limit))
+      : undefined;
+
+    if (paginationLimit === 0) {
+      return [];
+    }
+
     const params: any = {
       include: ['total_students', 'teachers', 'term', 'course_progress']
     };
@@ -240,18 +250,15 @@ export class CanvasClient {
       params.enrollment_state = enrollmentState;
     }
 
-    if (limit) {
-      params.per_page = Math.min(limit, 100);
+    if (paginationLimit) {
+      params.per_page = Math.min(paginationLimit, 100);
     }
 
-    const response = await this.client.get('/courses', { params });
-    let courses: CanvasCourse[] = response.data;
-
-    if (limit) {
-      courses = courses.slice(0, limit);
-    }
-
-    return courses;
+    const response = await this.client.get('/courses', {
+      params,
+      paginationLimit
+    } as PaginatedRequestConfig);
+    return response.data;
   }
 
   async getCourse(courseId: number): Promise<CanvasCourse> {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,6 @@
 // src/client.ts
 
-import axios, { AxiosInstance, AxiosError, AxiosRequestConfig } from 'axios';
+import axios, { AxiosInstance, AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
 import {
   CanvasCourse,
   CanvasAssignment,
@@ -101,7 +101,7 @@ export class CanvasClient {
 
           while (nextUrl && (!paginationLimit || allData.length < paginationLimit)) {
             console.error(`[Canvas API] GET ${nextUrl}`);
-            const nextResponse = await axios.get(nextUrl, paginationConfig);
+            const nextResponse = await this.fetchPaginatedPage(nextUrl, paginationConfig);
             allData = [...allData, ...nextResponse.data];
             nextUrl = nextResponse.headers.link
               ? this.getNextPageUrl(nextResponse.headers.link)
@@ -115,11 +115,11 @@ export class CanvasClient {
       },
       async (error: AxiosError) => {
         const config = error.config as any;
+        const retryCount = config?.__retryCount ?? 0;
         
         // Retry logic for specific errors
-        if (this.shouldRetry(error) && config && config.__retryCount < this.maxRetries) {
-          config.__retryCount = config.__retryCount || 0;
-          config.__retryCount++;
+        if (this.shouldRetry(error) && config && retryCount < this.maxRetries) {
+          config.__retryCount = retryCount + 1;
           
           const delay = this.retryDelay * Math.pow(2, config.__retryCount - 1); // Exponential backoff
           console.error(`[Canvas API] Retrying request (${config.__retryCount}/${this.maxRetries}) after ${delay}ms`);
@@ -128,56 +128,32 @@ export class CanvasClient {
           return this.client.request(config);
         }
 
-        // Transform error with better handling for non-JSON responses
-        if (error.response) {
-          const { status, data, headers } = error.response;
-          const contentType = headers?.['content-type'] || 'unknown';
-          console.error(`[Canvas API] Error response: ${status}, Content-Type: ${contentType}, Data type: ${typeof data}`);
-          
-          let errorMessage: string;
-          
-          try {
-            // Check if data is already a string (HTML error pages, plain text, etc.)
-            if (typeof data === 'string') {
-              errorMessage = data.length > 200 ? data.substring(0, 200) + '...' : data;
-            } else if (data && typeof data === 'object') {
-              // Handle structured Canvas API error responses
-              if ((data as any)?.message) {
-                errorMessage = (data as any).message;
-              } else if ((data as any)?.errors && Array.isArray((data as any).errors)) {
-                errorMessage = (data as any).errors.map((err: any) => err.message || err).join(', ');
-              } else {
-                errorMessage = JSON.stringify(data);
-              }
-            } else {
-              errorMessage = String(data);
-            }
-          } catch (jsonError) {
-            // Fallback if JSON operations fail
-            errorMessage = String(data);
-          }
-          
-          throw new CanvasAPIError(
-            `Canvas API Error (${status}): ${errorMessage}`, 
-            status, 
-            data
-          );
-        }
-        
-        // Handle network errors or other issues
-        if (error.request) {
-          console.error('[Canvas API] Network error - no response received:', error.message);
-          throw new CanvasAPIError(
-            `Network error: ${error.message}`,
-            0,
-            null
-          );
-        }
-        
-        console.error('[Canvas API] Unexpected error:', error.message);
-        throw error;
+        this.throwCanvasAPIError(error);
       }
     );
+  }
+
+  private async fetchPaginatedPage(url: string, config: AxiosRequestConfig): Promise<AxiosResponse<unknown[]>> {
+    let retryCount = 0;
+
+    while (true) {
+      try {
+        return await axios.get(url, config);
+      } catch (error) {
+        const axiosError = error as AxiosError;
+
+        if (this.shouldRetry(axiosError) && retryCount < this.maxRetries) {
+          retryCount++;
+          const delay = this.retryDelay * Math.pow(2, retryCount - 1);
+          console.error(`[Canvas API] Retrying pagination request (${retryCount}/${this.maxRetries}) after ${delay}ms`);
+
+          await this.sleep(delay);
+          continue;
+        }
+
+        this.throwCanvasAPIError(axiosError);
+      }
+    }
   }
 
   private shouldRetry(error: AxiosError): boolean {
@@ -189,6 +165,57 @@ export class CanvasClient {
 
   private sleep(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  private throwCanvasAPIError(error: AxiosError): never {
+    // Transform error with better handling for non-JSON responses
+    if (error.response) {
+      const { status, data, headers } = error.response;
+      const contentType = headers?.['content-type'] || 'unknown';
+      console.error(`[Canvas API] Error response: ${status}, Content-Type: ${contentType}, Data type: ${typeof data}`);
+
+      let errorMessage: string;
+
+      try {
+        // Check if data is already a string (HTML error pages, plain text, etc.)
+        if (typeof data === 'string') {
+          errorMessage = data.length > 200 ? data.substring(0, 200) + '...' : data;
+        } else if (data && typeof data === 'object') {
+          // Handle structured Canvas API error responses
+          if ((data as any)?.message) {
+            errorMessage = (data as any).message;
+          } else if ((data as any)?.errors && Array.isArray((data as any).errors)) {
+            errorMessage = (data as any).errors.map((err: any) => err.message || err).join(', ');
+          } else {
+            errorMessage = JSON.stringify(data);
+          }
+        } else {
+          errorMessage = String(data);
+        }
+      } catch (jsonError) {
+        // Fallback if JSON operations fail
+        errorMessage = String(data);
+      }
+
+      throw new CanvasAPIError(
+        `Canvas API Error (${status}): ${errorMessage}`,
+        status,
+        data
+      );
+    }
+
+    // Handle network errors or other issues
+    if (error.request) {
+      console.error('[Canvas API] Network error - no response received:', error.message);
+      throw new CanvasAPIError(
+        `Network error: ${error.message}`,
+        0,
+        null
+      );
+    }
+
+    console.error('[Canvas API] Unexpected error:', error.message);
+    throw error;
   }
 
   private getNextPageUrl(linkHeader: string): string | null {

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,10 @@ const RAW_TOOLS: Tool[] = [
     inputSchema: {
       type: "object",
       properties: {
-        include_ended: { type: "boolean", description: "Include ended courses" }
+        include_ended: { type: "boolean", description: "Include ended courses" },
+        limit: { type: "number", description: "Max number of courses to return (default: all)" },
+        enrollment_state: { type: "string", enum: ["active", "invited_or_pending", "completed"], description: "Filter by enrollment state" },
+        slim: { type: "boolean", description: "Return only id, name, course_code, term name, and workflow_state" }
       },
       required: []
     }
@@ -1302,8 +1305,17 @@ export class CanvasMCPServer {
 
           // Course management
           case "canvas_list_courses": {
-            const { include_ended = false } = args as { include_ended?: boolean };
-            const courses = await this.client.listCourses(include_ended);
+            const { include_ended = false, limit, enrollment_state, slim = false } = args as {
+              include_ended?: boolean; limit?: number; enrollment_state?: string; slim?: boolean;
+            };
+            const courses = await this.client.listCourses({ includeEnded: include_ended, limit, enrollmentState: enrollment_state });
+            if (slim) {
+              const slimCourses = courses.map(c => ({
+                id: c.id, name: c.name, course_code: c.course_code,
+                term: (c as any).term?.name, workflow_state: c.workflow_state
+              }));
+              return { content: [{ type: "text", text: JSON.stringify(slimCourses, null, 2) }] };
+            }
             return {
               content: [{ type: "text", text: this.serializeToolOutput(courses, includeRaw) }]
             };

--- a/tests/client.pagination.test.ts
+++ b/tests/client.pagination.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import axios from "axios";
 import { CanvasClient } from "../src/client.js";
+import { CanvasAPIError } from "../src/types.js";
 
 vi.mock("axios", () => {
   const mockedAxios = {
@@ -43,6 +44,19 @@ function paginatedResponse(
   };
 }
 
+function canvasApiAxiosError(status: number, data: any): any {
+  return {
+    message: `Request failed with status code ${status}`,
+    response: {
+      status,
+      data,
+      headers: {
+        "content-type": "application/json",
+      },
+    },
+  };
+}
+
 describe("CanvasClient pagination", () => {
   let client: CanvasClient;
   let responseHandler: ResponseHandler;
@@ -77,7 +91,9 @@ describe("CanvasClient pagination", () => {
 
     vi.mocked(axios.create).mockReturnValue(mockInstance as any);
     vi.mocked(axios.get).mockReset();
-    client = new CanvasClient("test-token", "canvas.example.edu");
+    client = new CanvasClient("test-token", "canvas.example.edu", {
+      retryDelay: 0,
+    });
   });
 
   it("passes listCourses limit into both Canvas per_page and the paginator cap", async () => {
@@ -145,5 +161,50 @@ describe("CanvasClient pagination", () => {
 
     expect(axios.get).toHaveBeenCalledTimes(2);
     expect(result.data).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+  });
+
+  it("wraps non-retryable paginated page failures as CanvasAPIError", async () => {
+    const page2Url = "https://canvas.example.edu/api/v1/courses?page=2";
+    vi.mocked(axios.get).mockRejectedValueOnce(
+      canvasApiAxiosError(401, { message: "Unauthorized" }),
+    );
+
+    let error: unknown;
+    try {
+      await responseHandler(paginatedResponse([{ id: 1 }], page2Url));
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(CanvasAPIError);
+    expect(error).toMatchObject({
+      message: "Canvas API Error (401): Unauthorized",
+      statusCode: 401,
+      response: { message: "Unauthorized" },
+    });
+  });
+
+  it("retries transient paginated page failures before returning data", async () => {
+    const page2Url = "https://canvas.example.edu/api/v1/courses?page=2";
+    vi.mocked(axios.get)
+      .mockRejectedValueOnce(
+        canvasApiAxiosError(500, { message: "Server error" }),
+      )
+      .mockResolvedValueOnce(paginatedResponse([{ id: 2 }]));
+
+    const result = await responseHandler(
+      paginatedResponse([{ id: 1 }], page2Url),
+    );
+
+    expect(axios.get).toHaveBeenCalledTimes(2);
+    expect(axios.get).toHaveBeenNthCalledWith(1, page2Url, {
+      headers: authHeaders,
+      timeout: 30000,
+    });
+    expect(axios.get).toHaveBeenNthCalledWith(2, page2Url, {
+      headers: authHeaders,
+      timeout: 30000,
+    });
+    expect(result.data).toEqual([{ id: 1 }, { id: 2 }]);
   });
 });

--- a/tests/client.pagination.test.ts
+++ b/tests/client.pagination.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import axios from "axios";
+import { CanvasClient } from "../src/client.js";
+
+vi.mock("axios", () => {
+  const mockedAxios = {
+    create: vi.fn(),
+    get: vi.fn(),
+  };
+
+  return {
+    default: mockedAxios,
+  };
+});
+
+const authHeaders = {
+  Authorization: "Bearer test-token",
+  "Content-Type": "application/json",
+};
+
+type ResponseHandler = (response: any) => Promise<any>;
+
+function linkHeader(nextUrl: string): string {
+  return `<${nextUrl}>; rel="next"`;
+}
+
+function paginatedResponse(
+  data: any[],
+  nextUrl?: string,
+  paginationLimit?: number,
+): any {
+  return {
+    data,
+    headers: {
+      "content-type": "application/json",
+      ...(nextUrl ? { link: linkHeader(nextUrl) } : {}),
+    },
+    config: {
+      headers: authHeaders,
+      timeout: 30000,
+      ...(paginationLimit !== undefined ? { paginationLimit } : {}),
+    },
+  };
+}
+
+describe("CanvasClient pagination", () => {
+  let client: CanvasClient;
+  let responseHandler: ResponseHandler;
+  let mockInstance: {
+    get: ReturnType<typeof vi.fn>;
+    post: ReturnType<typeof vi.fn>;
+    put: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+    interceptors: {
+      request: { use: ReturnType<typeof vi.fn> };
+      response: { use: ReturnType<typeof vi.fn> };
+    };
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockInstance = {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn(),
+      interceptors: {
+        request: { use: vi.fn() },
+        response: {
+          use: vi.fn((onFulfilled: ResponseHandler) => {
+            responseHandler = onFulfilled;
+          }),
+        },
+      },
+    };
+
+    vi.mocked(axios.create).mockReturnValue(mockInstance as any);
+    vi.mocked(axios.get).mockReset();
+    client = new CanvasClient("test-token", "canvas.example.edu");
+  });
+
+  it("passes listCourses limit into both Canvas per_page and the paginator cap", async () => {
+    mockInstance.get.mockResolvedValue({ data: [] });
+
+    await client.listCourses({ limit: 5, enrollmentState: "active" });
+
+    expect(mockInstance.get).toHaveBeenCalledWith("/courses", {
+      params: {
+        include: ["total_students", "teachers", "term", "course_progress"],
+        state: ["available", "completed"],
+        enrollment_state: "active",
+        per_page: 5,
+      },
+      paginationLimit: 5,
+    });
+  });
+
+  it("does not fetch a next page when the first page already satisfies the limit", async () => {
+    const firstPage = Array.from({ length: 10 }, (_, index) => ({
+      id: index + 1,
+    }));
+
+    const result = await responseHandler(
+      paginatedResponse(
+        firstPage,
+        "https://canvas.example.edu/api/v1/courses?page=2",
+        5,
+      ),
+    );
+
+    expect(axios.get).not.toHaveBeenCalled();
+    expect(result.data).toEqual(firstPage.slice(0, 5));
+  });
+
+  it("stops pagination as soon as a cross-page limit is satisfied", async () => {
+    const page2Url = "https://canvas.example.edu/api/v1/courses?page=2";
+    const page3Url = "https://canvas.example.edu/api/v1/courses?page=3";
+    vi.mocked(axios.get).mockResolvedValueOnce(
+      paginatedResponse([{ id: 3 }, { id: 4 }], page3Url, 3),
+    );
+
+    const result = await responseHandler(
+      paginatedResponse([{ id: 1 }, { id: 2 }], page2Url, 3),
+    );
+
+    expect(axios.get).toHaveBeenCalledTimes(1);
+    expect(axios.get).toHaveBeenCalledWith(page2Url, {
+      headers: authHeaders,
+      timeout: 30000,
+    });
+    expect(result.data).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+  });
+
+  it("continues through every linked page when no limit is set", async () => {
+    const page2Url = "https://canvas.example.edu/api/v1/courses?page=2";
+    const page3Url = "https://canvas.example.edu/api/v1/courses?page=3";
+    vi.mocked(axios.get)
+      .mockResolvedValueOnce(paginatedResponse([{ id: 2 }], page3Url))
+      .mockResolvedValueOnce(paginatedResponse([{ id: 3 }]));
+
+    const result = await responseHandler(
+      paginatedResponse([{ id: 1 }], page2Url),
+    );
+
+    expect(axios.get).toHaveBeenCalledTimes(2);
+    expect(result.data).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+  });
+});


### PR DESCRIPTION
## Summary

- brings in PR #14's pagination recursion/auth fix and list_courses params
- fixes the unresolved limit issue so auto-pagination stops once enough rows are collected
- adds regression coverage for first-page limits, cross-page limits, and unlimited pagination

## Validation

- npm test -- tests/client.pagination.test.ts
- npm test
- npm run type-check
- npm run build
- git diff --check

Note: npm run lint / npm run precommit are blocked by the existing missing ESLint config in this repo.

Supersedes #14.