### PR TITLE
chore(deps): bump @modelcontextprotocol/sdk to ^1.30.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.27.1",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "axios": "^1.13.5",
         "dotenv": "^17.3.1"
       },
@@ -843,12 +843,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "npm": ">=8.0.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "axios": "^1.13.5",
     "dotenv": "^17.3.1"
   },


### PR DESCRIPTION
Closes #16 (the 1.x half of it — see the note on v2 below).

Bumps `@modelcontextprotocol/sdk` from `^1.27.1` to `^1.30.0`.

### Verification

Run against this branch, on Node 22:

| Check | Result |
| --- | --- |
| `npm run type-check` | pass (exit 0) |
| `npm run build` | pass (exit 0) |
| `npm test` | pass — 9/9 tests, 2 files |

No source changes were needed. The lockfile diff touches only the SDK's own
`version`/`resolved`/`integrity` entries, plus the SDK's declared range for
`@hono/node-server` widening to `^1.19.9 || ^2.0.5` — nothing else re-resolved, and the
installed `@hono/node-server` is unchanged at 1.19.9.

I ran `type-check` and the test suite on `main` at 1.27.1 first, so the "green" above is a
comparison against a known-green baseline rather than an assumption.

`npm run lint` fails on this branch, but it fails identically on `main`: there is no
ESLint config file in the repo, so ESLint 8 exits with "couldn't find a configuration
file". That is pre-existing and unrelated to this change, so I have left it alone rather
than widen the diff — happy to open a separate issue or PR for it if that would be useful.

### What's in 1.28.0 … 1.30.0 that matters here

This server exposes Streamable HTTP, so these are the relevant ones:

- SSE keep-alive comment frames are now emitted from the Streamable HTTP server
  transport, plus a fix to the keep-alive timer lifecycle
- `Content-Type` is validated by parsed media type instead of a substring match
- a stdio buffer limit for the v1 transport
- Zod 3.25 method literal support, and zod issues prioritised/formatted in server errors

### A note on the "v2.0.0" half of #16

The issue suggests upgrading to "v1.29.0 (current stable) or v2.0.0 (available after
07/28)". Two things worth flagging, both checked against the registry today rather than
from release notes:

1. **`@modelcontextprotocol/sdk@2.0.0` does not exist.** `npm view @modelcontextprotocol/sdk@2`
   returns a 404. The `sdk` package's `latest` is `1.30.0` (published 2026-07-27), which is
   why this PR targets 1.30.0 rather than 1.29.0.
2. **v2 is a package split, not a version bump of `sdk`.** It shipped as
   `@modelcontextprotocol/{core,client,server,node,express,hono,fastify,server-legacy}`,
   all at `2.0.0`, ~6 hours after 1.30.0 on the same day. Both lines are maintained; the v1
   monolith is not deprecated.

So v2 can't be reached by editing a version range — it's an import rewrite. For this
codebase specifically, I resolved where each of your four import sites lands (verified by
installing the v2 packages and reading their actual exports):

| today | in v2 |
| --- | --- |
| `Server` from `sdk/server/index.js` | `@modelcontextprotocol/server` (root) |
| `StdioServerTransport` from `sdk/server/stdio.js` | `@modelcontextprotocol/server/stdio` |
| `StreamableHTTPServerTransport` from `sdk/server/streamableHttp.js` | `NodeStreamableHTTPServerTransport` from `@modelcontextprotocol/node` |
| `CallToolRequestSchema`, `ListToolsRequestSchema`, `ListResourcesRequestSchema`, `ReadResourceRequestSchema` from `sdk/types.js` | **not exported** — see below |

The last row is the real cost. Those four `*RequestSchema` constants are not part of v2's
public export surface; the schemas live under a `specTypeSchemas` map keyed without the
`Schema` suffix (`CallToolRequest`, `ListToolsRequest`, …). Since every
`this.server.setRequestHandler(XRequestSchema, …)` call site depends on them, a v2 move is
a real refactor of the request-handling layer, not a mechanical find-and-replace.

Two traps I hit while checking, in case they save you time:

- `@modelcontextprotocol/server-legacy` sounds like the compatibility shim for exactly this
  situation, but it isn't — it's a frozen copy of v1's **SSE transport and OAuth helpers
  only**, it does not export the low-level `Server` class, and npm prints a deprecation
  warning on install. The low-level `Server` is in `@modelcontextprotocol/server`.
- I expected `"moduleResolution": "node"` in your `tsconfig.json` to be a blocker for the v2
  packages' `exports` maps. I tested it and it isn't — both the root and subpath imports
  resolve fine under node10 resolution. Ignore that concern if you run into it repeated
  elsewhere.

None of that is a recommendation to move to v2 — 1.30.0 is a perfectly good place to sit,
and the two lines serve the same protocol revision by default. I just didn't want the
"upgrade to 2.0.0" framing in #16 to send anyone hunting for a package that isn't there.

### Disclosure

I maintain a different Canvas LMS MCP server, so I'd read this space anyway and had already
done the v2 legwork for my own codebase — it seemed worth passing on rather than sitting on
it. I'm not asking for anything in return and there's nothing of mine referenced in this
change; take it, modify it, or close it, whichever is least work for you. If you'd rather
own the SDK bump yourself, closing this is a completely fine outcome and I won't re-open it.

The CHANGELOG is deliberately untouched — its most recent entry is 2.2.3 while
`package.json` is at 2.3.1, so I didn't want to guess at how you'd want this recorded or
what version to file it under.
